### PR TITLE
#169798880 Delete a specific red-flag endpoint

### DIFF
--- a/src/controllers/incident.controller.js
+++ b/src/controllers/incident.controller.js
@@ -149,6 +149,28 @@ export const incidentController = {
       success: true,
       details: redflag
     });
+  },
+  deleteRedflag: (req, res) => {
+    const deleteRedFlag = incidents.findIndex((item) => item.incidentId.toString() === req.params.incidentId);
+    if (deleteRedFlag > -1) {
+      if (incidents[deleteRedFlag].status != "pending") {
+        return res.status(404).json({
+          status: 404,
+          data: {
+            message: "You are not allowed to update this incident",
+          },
+        });
+      }
+
+      incidents.splice(deleteRedFlag, 1);
+      return res.status(200).send({
+        status: 200,
+        data: {
+          message: "Red-flag successfully deleted",
+        },
+      });
+    }
+    return 0;
   }
 
 };

--- a/src/routes/v1/incident.routes.js
+++ b/src/routes/v1/incident.routes.js
@@ -9,5 +9,7 @@ router.patch("/red-flags/:incidentId/comment",verifyToken, incidentController.up
 router.patch("/red-flags/:incidentId/location",verifyToken, incidentController.updateLocation );
 router.get("/red-flags",verifyToken, incidentController.getAllRedflags );
 router.get("/red-flags/:incidentId",verifyToken, incidentController.getSpecificRedflag );
+router.delete("/red-flags/:incidentId",verifyToken, incidentController.deleteRedflag );
+
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?
- It creates a delete a specific red-flag endpoint
#### Description of Task to be completed?
-  Delete a specific red-flag endpoint
#### How should this be manually tested?
 - Clone Broadcaster  on your computer and open the older in your VS Code or any other HTML IDE. in your terminal, run nodemon by typing npm start and then open your postman and run http://localhost:4000/api/v1/red-flags/id under DELETE function and in body, insert credentials and click on send
- in your VSCode after running nodemon, you can click on Ctrl + the link in the terminal where you see the server running on http://localhost:4000/api/v1/red-flags/id
#### What are the relevant pivotal tracker stories?
- [#169798880](https://www.pivotaltracker.com/story/show/169798880) 

