### PR TITLE
ft(api):  create intervention endpoints

### DIFF
--- a/src/controllers/incident.controller.js
+++ b/src/controllers/incident.controller.js
@@ -64,7 +64,8 @@ export const incidentController = {
   },
   updateComment: (req, res) => {
     if (req.user.role === 'citizen') {
-      const index = incidents.findIndex((item) => item.incidentId.toString() === req.params.incidentId);
+      const index = incidents.findIndex((item) => 
+        item.incidentId.toString() === req.params.incidentId);
       if (index > -1) {
         if (incidents[index].status != 'pending') {
           return res.status(404).json({
@@ -132,27 +133,7 @@ export const incidentController = {
       },
     });
   },
-  getAllRedflags: (req, res) => {
-    const redflags = incidents.filter((user) => user.type === 'redflag');
-    return res.status(200).send({
-      status: 200,
-      data: redflags,
-    });
-  },
-  getSpecificRedflag: (req, res) => {
-    const redflag = incidents.find((item) => item.incidentId.toString() === req.params.incidentId);
-    if (!redflag || redflag.type !== 'redflag') {
-      return res.status(404).send({
-        success: false,
-        message: 'The red-flag does not exist, check your ID',
-      });
-    }
-    return res.status(200).send({
-      success: true,
-      details: redflag,
-    });
-  },
-  deleteRedflag: (req, res) => {
+  deleteIncident: (req, res) => {
     const deleteRedFlag = incidents.findIndex((item) => item.incidentId.toString() === req.params.incidentId);
     if (deleteRedFlag > -1) {
       if (incidents[deleteRedFlag].status != 'pending') {

--- a/src/controllers/intervention.controller.js
+++ b/src/controllers/intervention.controller.js
@@ -1,0 +1,26 @@
+/* eslint-disable max-len */
+import { incidents } from '../db/data';
+// eslint-disable-next-line import/prefer-default-export
+export const interventionController = {
+
+  getAllInterventions: (req, res) => {
+    const interventions = incidents.filter((user) => user.type === 'intervention');
+    return res.status(200).send({
+      status: 200,
+      data: interventions,
+    });
+  },
+  getSpecificIntervention: (req, res) => {
+    const intervention = incidents.find((item) => item.incidentId.toString() === req.params.incidentId);
+    if (!intervention || intervention.type !== 'intervention') {
+      return res.status(404).send({
+        success: false,
+        message: 'The intervention does not exist, check your ID',
+      });
+    }
+    return res.status(200).send({
+      success: true,
+      details: intervention,
+    });
+  },
+};

--- a/src/controllers/redflag.controller.js
+++ b/src/controllers/redflag.controller.js
@@ -1,0 +1,29 @@
+/* eslint-disable import/prefer-default-export */
+/* eslint-disable max-len */
+/* eslint-disable eqeqeq */
+/* eslint-disable comma-dangle */
+import { incidents } from '../db/data';
+
+export const redflagController = {
+  getAllRedflags: (req, res) => {
+    const redflags = incidents.filter((user) => user.type === 'redflag');
+    return res.status(200).send({
+      status: 200,
+      data: redflags,
+    });
+  },
+  getSpecificRedflag: (req, res) => {
+    const redflag = incidents.find((item) => item.incidentId.toString() === req.params.incidentId);
+    if (!redflag || redflag.type !== 'redflag') {
+      return res.status(404).send({
+        success: false,
+        message: 'The red-flag does not exist, check your ID',
+      });
+    }
+    return res.status(200).send({
+      success: true,
+      details: redflag,
+    });
+  },
+
+};

--- a/src/routes/v1/incident.routes.js
+++ b/src/routes/v1/incident.routes.js
@@ -1,15 +1,23 @@
 import express from 'express';
 import { incidentController } from '../../controllers/incident.controller';
+import { redflagController } from '../../controllers/redflag.controller';
+import { interventionController } from '../../controllers/intervention.controller';
 import verifyToken from '../../middleware/token.middleware';
 
 const router = express.Router();
+// full incident
+router.post('/incident', verifyToken, incidentController.createIncident);
+router.patch('/incident/:incidentId/comment', verifyToken, incidentController.updateComment);
+router.patch('/incident/:incidentId/location', verifyToken, incidentController.updateLocation);
+router.delete('/incident/:incidentId', verifyToken, incidentController.deleteIncident);
 
-router.post('/red-flags', verifyToken, incidentController.createIncident);
-router.patch('/red-flags/:incidentId/comment', verifyToken, incidentController.updateComment);
-router.patch('/red-flags/:incidentId/location', verifyToken, incidentController.updateLocation);
-router.get('/red-flags', verifyToken, incidentController.getAllRedflags);
-router.get('/red-flags/:incidentId', verifyToken, incidentController.getSpecificRedflag);
-router.delete('/red-flags/:incidentId', verifyToken, incidentController.deleteRedflag);
 
+// red-flags
+router.get('/red-flags', verifyToken, redflagController.getAllRedflags);
+router.get('/red-flags/:incidentId', verifyToken, redflagController.getSpecificRedflag);
+
+// interventions
+router.get('/interventions', verifyToken, interventionController.getAllInterventions);
+router.get('/interventions/:incidentId', verifyToken, interventionController.getSpecificIntervention);
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?
- It creates intervention endpoints
#### Description of Task to be completed?
- added a get all and get specific intervention endpoints
- to improve maintainability, I created a separate controller file for incidents, red-flags, and interventions
#### How should this be manually tested?
 - Clone free mentors on your computer and open the older in your VS Code or any other HTML IDE. in your terminal, run npm run dev
- Go to postman and use http://localhost/api/v1/auth/signup under POST to sign up and generate a token and then create an incident by using http://localhost/api/v1/incident under POST which creates an incident(red flag/ intervention) upon your type specifications. If you specified type as intervention, to view your intervention, create another request with http://localhost/api/v1/interventions under GET to view all interventions and http://localhost/api/v1/interventions/<:incident-id under GETto view a specific intervention record

#### What are the relevant pivotal tracker stories? 
- [#169886766](https://www.pivotaltracker.com/story/show/169886766) 

